### PR TITLE
TTS - Fix crash on second pass, fix azure SSML when using pause

### DIFF
--- a/TTS.py
+++ b/TTS.py
@@ -112,7 +112,7 @@ def synthesize_text_azure(text, speedFactor, voiceName, languageCode):
     # Create SSML syntax for Azure TTS
     ssml = f"<speak version='1.0' xml:lang='{languageCode}' xmlns='http://www.w3.org/2001/10/synthesis' " \
         "xmlns:mstts='http://www.w3.org/2001/mstts'>" \
-        f"<voice name='{voiceName}{pauseTag}'>" \
+        f"<voice name='{voiceName}'>{pauseTag}" \
         f"<prosody rate='{rate}'>{text}</prosody></voice></speak>"
 
     speech_config = speechsdk.SpeechConfig(subscription=AZURE_SPEECH_KEY, region=AZURE_SPEECH_REGION)
@@ -351,6 +351,7 @@ def synthesize_dictionary(subsDict, langDict, skipSynthesize=False, secondPass=F
             keyIndex = list(subsDict.keys()).index(key)
             print(f" Synthesizing TTS Line: {keyIndex+1} of {len(subsDict)}", end="\r")
         else:
+            keyIndex = list(subsDict.keys()).index(key)
             print(f" Synthesizing TTS Line (2nd Pass): {keyIndex+1} of {len(subsDict)}", end="\r")
     print("                                               ") # Clear the line
     return subsDict

--- a/TTS.py
+++ b/TTS.py
@@ -345,13 +345,12 @@ def synthesize_dictionary(subsDict, langDict, skipSynthesize=False, secondPass=F
 
         subsDict[key]['TTS_FilePath'] = filePath
 
+        # Get key index
+        keyIndex = list(subsDict.keys()).index(key)
         # Print progress and overwrite line next time
         if not secondPass:
-            # Get key index
-            keyIndex = list(subsDict.keys()).index(key)
             print(f" Synthesizing TTS Line: {keyIndex+1} of {len(subsDict)}", end="\r")
         else:
-            keyIndex = list(subsDict.keys()).index(key)
             print(f" Synthesizing TTS Line (2nd Pass): {keyIndex+1} of {len(subsDict)}", end="\r")
     print("                                               ") # Clear the line
     return subsDict


### PR DESCRIPTION
<!--# PLEASE ONLY SUBMIT PULL REQUESTS FOR BUG FIXES OR LEGITIMATELY USEFUL ADDITIONAL FUNCTIONALITY
## I know many of you are enthusiastic to help but I don't want this project to become bloated

--------
-->
### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Proposed Changes
- Move the pauseTag to inside the voice body instead of as a property
- Move keyIndex assignment outside of condition for loop to work when synthesizing on the second pass


### Additional Info
- Fixes #15
- Fixes #16 

### Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested that the code works

## Required:
- By contributing to this project, you agree to the terms of the GPLv3 license, and agree to grant the project owner the right to also provide or sell this software, including your contribution, to anyone under any other license, with no compensation to you.
- [X] I agree